### PR TITLE
Added 3 POST endpoints

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -72,9 +72,14 @@ app.MapGet("/api/appointments/{id}", (HillarysHairCareDbContext db, int id) =>
             Price = aps.Service.Price
         }).ToList()
     }).SingleOrDefault(a => a.Id == id);
+});
 
-
-
+// Add a new appointment
+app.MapPost("/api/appointments", (HillarysHairCareDbContext db, Appointment appointment) => 
+{
+    db.Appointments.Add(appointment);
+    db.SaveChanges();
+    return Results.Created($"/api/appointments/{appointment.Id}", appointment);
 });
 
 //Customers
@@ -99,8 +104,13 @@ app.MapGet("/api/customers/{id}", (HillarysHairCareDbContext db, int id) =>
     }).SingleOrDefault();
 });
 
-
-
+// Add a new customer
+app.MapPost("/api/customers", (HillarysHairCareDbContext db, Customer customer) => 
+{
+    db.Customers.Add(customer);
+    db.SaveChanges();
+    return Results.Created($"/api/customers/{customer.Id}", customer);
+});
 
 //Services
 
@@ -139,6 +149,13 @@ app.MapGet("/api/stylists/{id}", (HillarysHairCareDbContext db, int id) =>
     }).SingleOrDefault();
 });
 
+// Add a new customer
+app.MapPost("/api/stylists", (HillarysHairCareDbContext db, Stylist stylist) => 
+{
+    db.Stylists.Add(stylist);
+    db.SaveChanges();
+    return Results.Created($"/api/stylists/{stylist.Id}", stylist);
+});
 
 app.Run();
 


### PR DESCRIPTION
# Description

There are now three more endpoints for adding items to our database. Specifically, we've implemented the endpoints for (1) adding an appointment, (2) adding a customer, and (3) adding a stylist.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] POST a new appointment to http://localhost:5001/api/appointments -- raw data can be 
{
    "stylistid": 3,
    "customerid": 5,
    "time": "2025-06-05T15:45:00Z"
}
- [ ] POST a new customer to http://localhost:5001/api/customers -- raw data can be 
{
    "name": "Chowda",
}
- [ ] POST a new stylist to http://localhost:5001/api/stylists -- raw data can be 
{
    "name": "Deedubya",
    "isactive": false
}

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings