### PR TITLE
Edit Stylist and Appointment

### DIFF
--- a/Models/Stylist.cs
+++ b/Models/Stylist.cs
@@ -8,5 +8,5 @@ public class Stylist
 
     [Required]
     public string Name { get; set; }
-    public bool IsActive { get; set; }
+    public bool IsActive { get; set; } = true;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Homepage from "./components/Homepage";
 import AddCustomer from "./components/AddCustomer";
 import EditStylist from "./components/EditStylist";
 import AddStylist from "./components/AddStylist";
+import EditAppointment from "./components/EditAppointment";
 
 
 function App() {
@@ -17,6 +18,7 @@ function App() {
           <Route path="/add-stylist" element={<AddStylist />} />
           <Route path="/add-customer" element={<AddCustomer />} />
           <Route path="/edit-stylist" element={<EditStylist />} />
+          <Route path="/edit-appointment/:id" element={<EditAppointment />} />
         </Routes>
       </main>
     </>

--- a/client/src/components/EditAppointment.jsx
+++ b/client/src/components/EditAppointment.jsx
@@ -1,3 +1,71 @@
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import {
+  editAppointment,
+  getAppointmentById,
+} from "../services/AppointmentServices";
+import { getServices } from "../services/ServicesServices";
+
 export default function EditAppointment() {
-  return <h2>Edit </h2>;
+  const [appointment, setAppointment] = useState({
+    serviceIds: [],
+  });
+  const [services, setServices] = useState([]);
+  const { id } = useParams();
+
+useEffect(() => {
+  const fetchData = async () => {
+    const fetchedAppointment = await getAppointmentById(id);
+    const allServices = await getServices();
+
+    // Create serviceIds from Services array
+    const serviceIds = fetchedAppointment.services?.map((s) => s.id) || [];
+
+    setAppointment({ ...fetchedAppointment, serviceIds });
+    setServices(allServices);
+  };
+
+  fetchData();
+}, [id]);
+
+
+  const handleServices = (id) => {
+    setAppointment((previous) => ({
+      ...previous,
+      serviceIds: previous.serviceIds.includes(id)
+        ? previous.serviceIds.filter((serviceId) => serviceId !== id)
+        : [...previous.serviceIds, id],
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    try {
+      await editAppointment(id, appointment.serviceIds);
+      alert("Appointment updated successfully!");
+    } catch (error) {
+      console.error(error);
+      alert("There was an error updating the appointment.");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Edit Appointment Services</h2>
+      {services.map((service) => (
+        <div key={service.id}>
+          <input
+            type="checkbox"
+            value={service.id}
+            checked={appointment.serviceIds?.includes(service.id)}
+            onChange={() => handleServices(service.id)}
+          ></input>
+          {service.name}(${service.price})
+        </div>
+      ))}
+
+      <button type="submit">Update Appointment</button>
+    </form>
+  );
 }

--- a/client/src/components/EditStylist.jsx
+++ b/client/src/components/EditStylist.jsx
@@ -1,3 +1,57 @@
+import { useEffect, useState } from "react";
+import { getStylists, editStylist } from "../services/StylistServices";
+
 export default function EditStylist() {
-  return <h2>Edit </h2>;
-}
+  const [stylists, setStylists] = useState([]);
+  const [isActive, setIsActive] = useState(true);
+  const [stylist, setStylist] = useState("")
+  
+  useEffect(() => {
+    getStylists().then(setStylists);
+  }, []);
+
+  const stylistChange = async (event) => {
+    const id = parseInt(event.target.value);
+    setStylist(id);
+    const newStylist = stylists.find((s) => s.id == id);
+    if (newStylist) {
+    setIsActive(newStylist.isActive);
+    }
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    
+    try {
+      await editStylist(stylist, { isActive });
+      alert("Stylist updated successfully!");
+    } catch (error) {
+      console.error(error);
+      alert("There was an error updating the stylist.");
+    }
+
+  }
+
+  return (
+  <form onSubmit = {handleSubmit}>
+    <h2>Edit Stylist</h2>
+
+    <label>Select Stylist:</label>
+    <select value={stylist} onChange={stylistChange}>
+      <option value="">Choose Stylist</option>
+        {stylists.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+          </option>
+        ))}
+    </select>
+
+    <label>Active Status</label>
+    <input type="checkbox" value={true} checked={isActive === true} onChange={() => setIsActive (true)}></input>
+    Active
+    <input type="checkbox" value={false} checked={isActive === false} onChange={() => setIsActive (false)}></input>
+    Inactive
+
+    <button type="submit">Update Stylist</button>
+  </form>
+)}

--- a/client/src/components/Homepage.jsx
+++ b/client/src/components/Homepage.jsx
@@ -7,6 +7,7 @@ import { getCustomers } from "../services/CustomerServices";
 import { getStylists } from "../services/StylistServices";
 import { getServices } from "../services/ServicesServices";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function Homepage() {
   const [appointments, setAppointments] = useState([]);
@@ -26,17 +27,16 @@ export default function Homepage() {
 
   const fetchData = async () => {
     const [app, cust, sty, serv] = await Promise.all([
-  getAppointments(),
-  getCustomers(),  
-  getStylists(),   
-  getServices(),
-]);
+      getAppointments(),
+      getCustomers(),
+      getStylists(),
+      getServices(),
+    ]);
 
-setAppointments(app);
-setCustomers(cust);  
-setStylists(sty);    
-setServices(serv);
-
+    setAppointments(app);
+    setCustomers(cust);
+    setStylists(sty);
+    setServices(serv);
   };
 
   const handleDelete = async (id) => {
@@ -53,18 +53,26 @@ setServices(serv);
 
   const handleServices = (id) => {
     setNewAppointment((previous) => ({
-        ...previous,
-        serviceIds: previous.serviceIds.includes(id) ? previous.serviceIds.filter((serviceId) => serviceId !== id) : [...previous.serviceIds, id],
-    }))
-  }
-
-  const handleSubmit = async () => {
-    await createAppointment(newAppointment)
-
-    fetchData();
-    setNewAppointment({ stylistId: '', customerId: '', time: '', serviceIds: [] });
+      ...previous,
+      serviceIds: previous.serviceIds.includes(id)
+        ? previous.serviceIds.filter((serviceId) => serviceId !== id)
+        : [...previous.serviceIds, id],
+    }));
   };
 
+  const handleSubmit = async () => {
+    await createAppointment(newAppointment);
+
+    fetchData();
+    setNewAppointment({
+      stylistId: "",
+      customerId: "",
+      time: "",
+      serviceIds: [],
+    });
+  };
+
+  const navigate = useNavigate();
 
   return (
     //get all appointments
@@ -78,11 +86,13 @@ setServices(serv);
         }
       >
         <option value=""> Select a stylist </option>
-        {stylists.map((s) => (
-          <option key={s.id} value={s.id}>
-            {s.name}
-          </option>
-        ))}
+        {stylists
+          .filter((s) => s.isActive)
+          .map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
       </select>
       <label> Customer:</label>
       <select
@@ -127,7 +137,7 @@ setServices(serv);
             {a.customer?.name} has an appointment at {a.time} with{" "}
             {a.stylist?.name} for a {a.services.map((s) => s.name).join(", ")}.
             The total cost will be ${a.totalCost}.{"  "}
-            <button> Edit</button>
+            <button onClick={() => navigate(`/edit-appointment/${a.id}`)}> Edit</button>
             <button onClick={() => handleDelete(a.id)}> Delete</button>
           </li> // delete appointments
         ))}
@@ -135,5 +145,3 @@ setServices(serv);
     </div>
   );
 }
-
-//create appointments

--- a/client/src/services/AppointmentServices.jsx
+++ b/client/src/services/AppointmentServices.jsx
@@ -27,3 +27,29 @@ export const createAppointment = async (newAppointment) => {
     });
     return res.json();
 }
+
+//edit appointment
+export const editAppointment = async (id, serviceIds) => {
+    const res = await fetch(`${API}/appointments/${id}/services`, {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(serviceIds),
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to update appointment");
+    }
+
+    // Only return JSON if there is content
+    if (res.status !== 204) {
+        return res.json();
+    }
+};
+
+//get appointment by id
+export const getAppointmentById = async (id) => {
+    const res = await fetch (`${API}/appointments/${id}`);
+    return res.json ();
+}

--- a/client/src/services/StylistServices.jsx
+++ b/client/src/services/StylistServices.jsx
@@ -19,3 +19,23 @@ export const createStylist = async (newStylist) => {
     });
     return res.json();
 }
+
+//edit stylist
+export const editStylist = async (id, updatedStylist) => {
+    const res = await fetch(`${API}/stylists/${id}`, {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(updatedStylist),
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to update stylist");
+    }
+
+    // Only return JSON if there is content
+    if (res.status !== 204) {
+        return res.json();
+    }
+};


### PR DESCRIPTION
# Description

The user is now able to (1) navigate the the edit appointment page with any of the edit buttons next to an appointment, (2) change the service(s) for a selected appointment, and (3) navigate to the edit stylist page to make them active or inactive. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Select an appointment to edit, click on the Edit button, and change the service(s) associated with that appointment. When you hit the Update appointment button, those changes should be reflected on the homepage.
- [x] Click Edit Stylist on the nav bar. Then, on that new page, select a stylist, change their status from active --> inactive (or vice versa), then click submit to save that stylist's new activity state. The inactive stylists should no longer appear for the dropdown on the homepage.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings